### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,7 +55,7 @@ Project info
 ============
 
 * Free software: BSD license
-* `Documentation <http://drf-compound-fields.rtfd.org>`_
+* `Documentation <https://drf-compound-fields.readthedocs.io>`_
 * `Source code <https://github.com/estebistec/drf-compound-fields>`_
 * `Issue tracker <https://github.com/estebistec/drf-compound-fields/issues>`_
 * `CI server <https://travis-ci.org/estebistec/drf-compound-fields>`_


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.