### PR TITLE
ListField: redundant validation call that runs at wrong time

### DIFF
--- a/drf_compound_fields/fields.py
+++ b/drf_compound_fields/fields.py
@@ -45,7 +45,6 @@ class ListField(WritableField):
         return obj
 
     def from_native(self, data):
-        self.validate_is_list(data)
         if self.item_field and data:
             return [
                 self.item_field.from_native(item_data)


### PR DESCRIPTION
This causes spurious validation errors when using 'partial' serializers (PATCH requests) in DRF

I first noticed it because I would see errors like `picture_ids: %(value)s is not a list` in my tests 

I started looking into why the `%(value)s` was not substituted into the error string, suspecting a bug in our error response code

but it turns out due to exception being raised in the wrong phase by drf_compound_fields

when validation is performed at the normal time by DRF the value gets substituted properly https://github.com/encode/django-rest-framework/blob/2.4.4/rest_framework/fields.py#L326

I confirmed also that the `validate_is_list` method still gets called as intended after removing this line

I'm not sure why this validation call was added on this line originally, but the tests pass without it and removing it seems to prevent spurious errors